### PR TITLE
Reordena passos do deploy para reduzir tempo fora do ar.

### DIFF
--- a/scripts/snap-deploy-dev
+++ b/scripts/snap-deploy-dev
@@ -13,11 +13,11 @@ git pull --rebase
 
 export PDS_CARTAS_REPOSITORIO='https://github.com/servicosgovbr/cartas-de-teste.git'
 
+./build-all
+
 docker-compose stop portal1 portal2
 docker-compose kill portal1 portal2
 docker-compose rm -f portal1 portal2
-
-./build-all
 
 docker-compose up -d
 docker-compose restart balanceador


### PR DESCRIPTION
Como o build das imagens pode demorar, vamos iniciar a criacao das
imagens atualizadas antes de paras os processos atuais.

Assim, reduzimos o tempo fora do ar dos serviços para apenas o tempo de
iniciar o processo.