### PR TITLE
Incluir repositório fonte de cartas de teste para o editor.

### DIFF
--- a/scripts/snap-deploy-dev
+++ b/scripts/snap-deploy-dev
@@ -12,6 +12,7 @@ cd '/root/docker'
 git pull --rebase
 
 export PDS_CARTAS_REPOSITORIO='https://github.com/servicosgovbr/cartas-de-teste.git'
+export EDS_CARTAS_REPOSITORIO='git@github.com:servicosgovbr/cartas-de-teste.git'
 
 docker-compose stop portal1 portal2
 docker-compose kill portal1 portal2


### PR DESCRIPTION
Como agora o script de deploy para o ambiente dev está recriando todas
as imagens, precisamos também de redefinir o repositório fonte de cartas
de serviço.