### PR TITLE
Define um fallback para o endereço do repositorio de cartas.

### DIFF
--- a/scripts/portal-de-servicos.default.config
+++ b/scripts/portal-de-servicos.default.config
@@ -15,6 +15,10 @@ PDS_IMPORTADOR_INTERVALO="600000"
 ## Define a URL para o repositório onde o sistema irá buscar as cartas de serviços
 PDS_CARTAS_REPOSITORIO=https://github.com/servicosgovbr/cartas-de-servico.git
 
+## Define a URL para o repositório onde o sistema irá buscar as cartas de serviços
+## caso as váriaveis de ambiente sobrescreva PDS_CARTAS_REPOSITORIO e esteja em branco
+FALLBACK_PDS_CARTAS_REPOSITORIO=https://github.com/servicosgovbr/cartas-de-servico.git
+
 ## Desabilita o monitoramento e métricas do Piwik
 PDS_PIWIK_ENABLED=false
 

--- a/src/main/java/br/gov/servicos/importador/RepositorioCartasServico.java
+++ b/src/main/java/br/gov/servicos/importador/RepositorioCartasServico.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import static lombok.AccessLevel.PRIVATE;
 import static org.eclipse.jgit.api.ResetCommand.ResetType.HARD;
 import static org.eclipse.jgit.merge.MergeStrategy.THEIRS;
+import static org.springframework.util.StringUtils.isEmpty;
 
 @Slf4j
 @Component
@@ -34,8 +35,10 @@ public class RepositorioCartasServico {
     File caminhoLocal;
 
     @Autowired
-    public RepositorioCartasServico(@Value("${pds.cartas.repositorio}") String urlRepositorio) {
-        this.urlRepositorio = urlRepositorio;
+    public RepositorioCartasServico(@Value("${pds.cartas.repositorio}") String urlRepositorio,
+                                    @Value("${fallback.pds.cartas.repositorio}") String urlFallbackRepositorio) {
+        String url = isEmpty(urlRepositorio) ? urlFallbackRepositorio : urlRepositorio;
+        this.urlRepositorio = url;
     }
 
     @SneakyThrows

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -58,3 +58,8 @@ pds:
       - trabalho
       - educacao
       - economia-e-financas
+
+fallback:
+  pds:
+    cartas:
+      repositorio: "https://github.com/servicosgovbr/cartas-de-servico.git"

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -54,3 +54,8 @@ pds:
     telefones:
       arquivo-nacional-an: "123"
       banco-central-do-brasil-bcb: "0800 456 789"
+
+fallback:
+  pds:
+    cartas:
+      repositorio: "https://github.com/servicosgovbr/cartas-de-teste.git"


### PR DESCRIPTION
A opção de qual repositório será a fonte de informações para o editor é
configurável através de variaveis de ambiente e arquivos de
configuração.

Uma situação que impediria o funcionamento do editor é caso a váriavel
de ambiente que é utilizada para apontar para o repositório de cartas
esteja definida, mas possua um valor em branco.

Isso pode acontecer quando exportamos uma váriavel shell da seguinte
maneira antes de subir a aplicação.

```bash
export EDS_CARTAS_REPOSITORIO=''
```

Para evitar que a aplicação quebre ao subir com um valor em branco, esse
commit introduz uma váriavel extra, para caso não exista um valor, nós
utilizaremos o repositório oficial através do ssh, para que mudanças
sejam enviadas utilizando a chave de acesso.